### PR TITLE
Change the time-to-live for queue messages

### DIFF
--- a/src/Tools/CsvImporter/Extensions/ServiceSetup/QueueClientServiceStartupExtensions.cs
+++ b/src/Tools/CsvImporter/Extensions/ServiceSetup/QueueClientServiceStartupExtensions.cs
@@ -12,4 +12,11 @@ internal static class QueueClientServiceStartupExtensions
 
         return services;
     }
+
+    public static IServiceCollection AddCsvImporterQueueClientService(this IServiceCollection services)
+    {
+        services.AddSingleton<IQueueClientService, QueueClientService>(service => new("DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=https://127.0.0.1:10001/devstoreaccount1;"));
+
+        return services;
+    }
 }

--- a/src/Tools/CsvImporter/Program.cs
+++ b/src/Tools/CsvImporter/Program.cs
@@ -158,11 +158,19 @@ builder.Services
 // Add the QueueClientService to the host.
 try
 {
-    builder.Services
-        .AddCsvImporterQueueClientService(
-            queueUri: csvImporterConfig.QueueUri!,
-            tokenCredential: AuthUtils.CreateTokenCredential(csvImporterConfig.QueueUri!)
+    if (builder.Configuration.GetValue<bool>("USE_LOCAL_QUEUE"))
+    {
+        builder.Services
+            .AddCsvImporterQueueClientService();
+    }
+    else
+    {
+        builder.Services
+            .AddCsvImporterQueueClientService(
+                queueUri: csvImporterConfig.QueueUri!,
+                tokenCredential: AuthUtils.CreateTokenCredential(csvImporterConfig.QueueUri!)
         );
+    }
 }
 catch (Exception ex)
 {

--- a/src/Tools/CsvImporter/Services/MainService/MainService.cs
+++ b/src/Tools/CsvImporter/Services/MainService/MainService.cs
@@ -291,7 +291,8 @@ public sealed class MainService : IMainService, IHostedService, IDisposable
             try
             {
                 await _queueClientService.AuthUpdateQueueClient.SendMessageAsync(
-                    messageText: userItemJson
+                    messageText: userItemJson,
+                    timeToLive: TimeSpan.FromMinutes(30)
                 );
             }
             catch (Exception)


### PR DESCRIPTION
This PR changes the TTL for messages inserted into the queue, via `EntraMfaPrefillinator.Tools.CsvImporter`, to only last 30 minutes.