### PR TITLE
Add first run queue message TTL and add configurable TTL

### DIFF
--- a/src/Tools/CsvImporter/JsonSourceGen/ConfigJsonContext.cs
+++ b/src/Tools/CsvImporter/JsonSourceGen/ConfigJsonContext.cs
@@ -14,6 +14,7 @@ namespace EntraMfaPrefillinator.Tools.CsvImporter;
 )]
 [JsonSerializable(typeof(CsvImporterConfig))]
 [JsonSerializable(typeof(CsvImporterConfigFile))]
+[JsonSerializable(typeof(QueueMessageTimeToLiveConfig))]
 internal partial class ConfigJsonContext : JsonSerializerContext
 {
 }

--- a/src/Tools/CsvImporter/Models/CsvImporterConfig.cs
+++ b/src/Tools/CsvImporter/Models/CsvImporterConfig.cs
@@ -30,4 +30,7 @@ public sealed class CsvImporterConfig
     /// </summary>
     [JsonPropertyName("queueUri")]
     public string? QueueUri { get; set; }
+
+    [JsonPropertyName("queueMessageTTL")]
+    public QueueMessageTimeToLiveConfig QueueMessageTTL { get; set; } = new();
 }

--- a/src/Tools/CsvImporter/Models/QueueMessageTimeToLiveConfig.cs
+++ b/src/Tools/CsvImporter/Models/QueueMessageTimeToLiveConfig.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.Models;
+
+public sealed class QueueMessageTimeToLiveConfig
+{
+    [JsonPropertyName("firstRun")]
+    public TimeSpan FirstRun { get; set; } = TimeSpan.FromHours(12);
+
+    [JsonPropertyName("deltaRuns")]
+    public TimeSpan DeltaRuns { get; set; } = TimeSpan.FromMinutes(30);
+}


### PR DESCRIPTION
This PR adds two things:

1. The queue messages added during the first run will, by default, last longer than subsequent delta runs. This should account for the large amount of time it _could_ take to process all of the first run messages.
2. Adds two new config values to `config.json` for adjusting the TTL for both the first run and subsequent delta runs.