### PR TITLE
Modify the hosting lifecycle logging

### DIFF
--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -48,6 +48,8 @@ internal sealed class MainService : IHostedService, IDisposable
                 kind: ActivityKind.Internal
             );
 
+        _logger.LogInformation("Getting messages from queue...");
+
         NullableResponse<QueueMessage[]> queueMessages = await _queueClientService.AuthUpdateQueueClient.ReceiveMessagesAsync(
             maxMessages: _options.MaxMessages,
             cancellationToken: cancellationToken
@@ -335,8 +337,6 @@ internal sealed class MainService : IHostedService, IDisposable
 
         _runTask = RunAsync(_cts.Token);
 
-        _logger.LogInformation("MainService started.");
-
         return Task.CompletedTask;
     }
 
@@ -356,8 +356,6 @@ internal sealed class MainService : IHostedService, IDisposable
                     .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             }
         }
-
-        _logger.LogInformation("MainService stopped.");
     }
 
     /// <inheritdoc/>

--- a/src/Tools/CsvImporter/Services/MainService/MainService.cs
+++ b/src/Tools/CsvImporter/Services/MainService/MainService.cs
@@ -254,8 +254,6 @@ public sealed class MainService : IMainService, IHostedService, IDisposable
 
         _runTask = RunAsync(_cts.Token);
 
-        _logger.LogInformation("MainService started.");
-
         return Task.CompletedTask;
     }
 
@@ -274,7 +272,6 @@ public sealed class MainService : IMainService, IHostedService, IDisposable
                     .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
             }
         }
-        _logger.LogInformation("MainService stopped.");
     }
 
     public void Dispose()


### PR DESCRIPTION
## Description

This PR modifies the hosting lifecycle logging for the `MainService` in both `AuthUpdateApp` and `CsvImporter`. Specifically, the "MainService started" and "MainService stopped" messages have been removed.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None