### PR TITLE
Fix null reference exception with GraphClientService calls

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,8 @@
             "name": "Debug AuthUpdateApp",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/src/AuthUpdateApp/bin/Debug/net8.0/EntraMfaPrefillinator.AuthUpdateApp.dll",
-            "cwd": "${workspaceFolder}/src/AuthUpdateApp/bin/Debug/net8.0/",
+            "program": "${workspaceFolder}/artifacts/bin/AuthUpdateApp/debug/EntraMfaPrefillinator.AuthUpdateApp.dll",
+            "cwd": "${workspaceFolder}/artifacts/bin/AuthUpdateApp/debug/",
             "env": {
                 "DOTNET_ENVIRONMENT": "Development",
                 "USE_LOCAL_QUEUE": "true"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -186,10 +186,7 @@
 				"panel": "shared",
 				"showReuseMessage": true,
 				"clear": true
-			},
-			"dependsOn": [
-				"Clean AuthUpdateApp"
-			]
+			}
 		},
 		{
 			"label": "Clean AuthUpdateApp",

--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -295,7 +295,7 @@ internal sealed class MainService : IHostedService, IDisposable
         {
             try
             {
-                user = await _graphClientService.GetUserByUserNameAndEmployeeNumberAsync(queueItem.UserName, queueItem.EmployeeId, activity?.Id);
+                user = await _graphClientService.GetUserByUserNameAndEmployeeNumberAsync(queueItem.UserName, queueItem.EmployeeId, activity?.Id) ?? throw new NullReferenceException("Returned user was null.");
             }
             catch (Exception ex)
             {
@@ -310,7 +310,7 @@ internal sealed class MainService : IHostedService, IDisposable
         {
             try
             {
-                user = await _graphClientService.GetUserAsync(queueItem.UserPrincipalName, activity?.Id);
+                user = await _graphClientService.GetUserAsync(queueItem.UserPrincipalName, activity?.Id) ?? throw new NullReferenceException("Returned user was null.");
             }
             catch (Exception ex)
             {

--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -89,8 +89,6 @@ internal sealed class MainService : IHostedService, IDisposable
         activity?.SetStatus(ActivityStatusCode.Ok);
 
         _appLifetime.StopApplication();
-
-        return;
     }
 
     /// <summary>

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/AddEmailAuthenticationMethodAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/AddEmailAuthenticationMethodAsync.cs
@@ -74,10 +74,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/AddEmailAuthenticationMethodAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/AddEmailAuthenticationMethodAsync.cs
@@ -47,19 +47,37 @@ public partial class GraphClientService
                 json: apiResultString,
                 jsonTypeInfo: GraphJsonContext.Default.EmailAuthenticationMethod
             )!;
+
+            return emailAuthMethod;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return emailAuthMethod;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/AddPhoneAuthenticationMethodAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/AddPhoneAuthenticationMethodAsync.cs
@@ -48,19 +48,37 @@ public partial class GraphClientService
                 json: apiResultString,
                 jsonTypeInfo: GraphJsonContext.Default.PhoneAuthenticationMethod
             )!;
+
+            return phoneAuthMethod;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return phoneAuthMethod;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/AddPhoneAuthenticationMethodAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/AddPhoneAuthenticationMethodAsync.cs
@@ -75,10 +75,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/GetEmailAuthenticationMethodsAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/GetEmailAuthenticationMethodsAsync.cs
@@ -59,10 +59,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/GetEmailAuthenticationMethodsAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/GetEmailAuthenticationMethodsAsync.cs
@@ -32,19 +32,37 @@ public partial class GraphClientService
                 json: apiResultString,
                 jsonTypeInfo: GraphJsonContext.Default.GraphCollectionEmailAuthenticationMethod
             )!;
+
+            return emailAuthMethods.Value;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return emailAuthMethods.Value;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/GetPhoneAuthenticationMethodsAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/GetPhoneAuthenticationMethodsAsync.cs
@@ -32,19 +32,37 @@ public partial class GraphClientService
                 json: apiResultString,
                 jsonTypeInfo: GraphJsonContext.Default.GraphCollectionPhoneAuthenticationMethod
             )!;
+
+            return phoneAuthMethods.Value;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return phoneAuthMethods.Value;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/GetPhoneAuthenticationMethodsAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/GetPhoneAuthenticationMethodsAsync.cs
@@ -59,10 +59,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/GraphClientService/Users/GetUserAsync.cs
+++ b/src/Lib/Services/GraphClientService/Users/GetUserAsync.cs
@@ -60,10 +60,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/GraphClientService/Users/GetUserAsync.cs
+++ b/src/Lib/Services/GraphClientService/Users/GetUserAsync.cs
@@ -6,8 +6,8 @@ namespace EntraMfaPrefillinator.Lib.Services;
 public partial class GraphClientService
 {
     /// <inheritdoc />
-    public async Task<User> GetUserAsync(string userId) => await GetUserAsync(userId, null);
-    public async Task<User> GetUserAsync(string userId, string? parentActivityId)
+    public async Task<User?> GetUserAsync(string userId) => await GetUserAsync(userId, null);
+    public async Task<User?> GetUserAsync(string userId, string? parentActivityId)
     {
         using var activity = _activitySource.StartActivity(
             name: "GetUserAsync",
@@ -26,7 +26,7 @@ public partial class GraphClientService
             httpMethod: HttpMethod.Get
         ) ?? throw new Exception("API result was null.");
 
-        User user;
+        User? user;
         try
         {
             user = JsonSerializer.Deserialize(
@@ -34,24 +34,36 @@ public partial class GraphClientService
                 jsonTypeInfo: GraphJsonContext.Default.User
             )!;
 
-            if (string.IsNullOrEmpty(user.Id))
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, "User ID is null or empty.");
-                throw new Exception("User ID is null or empty.");
-            }
+            return user;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return user;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/Users/GetUserByUserNameAndEmployeeNumberAsync.cs
+++ b/src/Lib/Services/GraphClientService/Users/GetUserByUserNameAndEmployeeNumberAsync.cs
@@ -8,8 +8,8 @@ namespace EntraMfaPrefillinator.Lib.Services;
 public partial class GraphClientService
 {
     /// <inheritdoc />
-    public async Task<User> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber) => await GetUserByUserNameAndEmployeeNumberAsync(userName, employeeNumber, null);
-    public async Task<User> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber, string? parentActivityId)
+    public async Task<User?> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber) => await GetUserByUserNameAndEmployeeNumberAsync(userName, employeeNumber, null);
+    public async Task<User?> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber, string? parentActivityId)
     {
         using var activity = _activitySource.StartActivity(
             name: "GetUserByUserNameAndEmployeeNumberAsync",
@@ -53,7 +53,7 @@ public partial class GraphClientService
             httpMethod: HttpMethod.Get
         ) ?? throw new Exception("API result was null.");
         
-        User user;
+        User? user;
         GraphCollection<User> userCollection;
         try
         {
@@ -64,29 +64,41 @@ public partial class GraphClientService
 
             if (userCollection.Value is null)
             {
-                activity?.SetStatus(ActivityStatusCode.Error, "User collection value is null.");
-                throw new Exception("User collection value is null.");
+                return null;
             }
 
             user = Array.Find(userCollection.Value, item => item.OnPremisesSamAccountName == userName || item.EmployeeId == employeeNumber) ?? throw new Exception("User not found.");
 
-            if (string.IsNullOrEmpty(user.Id))
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, "User ID is null or empty.");
-                throw new Exception("User ID is null or empty.");
-            }
+            return user;
         }
-        catch
+        catch (ArgumentNullException)
         {
-            GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
-                json: apiResultString,
-                jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
-            );
-
-            activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
-            throw new Exception(errorResponse!.Error!.Message);
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
         }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
 
-        return user;
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw new Exception("An unknown error occurred.", ex);
+        }
     }
 }

--- a/src/Lib/Services/GraphClientService/Users/GetUserByUserNameAndEmployeeNumberAsync.cs
+++ b/src/Lib/Services/GraphClientService/Users/GetUserByUserNameAndEmployeeNumberAsync.cs
@@ -67,7 +67,7 @@ public partial class GraphClientService
                 return null;
             }
 
-            user = Array.Find(userCollection.Value, item => item.OnPremisesSamAccountName == userName || item.EmployeeId == employeeNumber) ?? throw new Exception("User not found.");
+            user = Array.Find(userCollection.Value, item => item.OnPremisesSamAccountName == userName || item.EmployeeId == employeeNumber);
 
             return user;
         }
@@ -95,10 +95,10 @@ public partial class GraphClientService
             }
             throw;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             activity?.SetStatus(ActivityStatusCode.Error);
-            throw new Exception("An unknown error occurred.", ex);
+            throw;
         }
     }
 }

--- a/src/Lib/Services/interfaces/IGraphClientService.cs
+++ b/src/Lib/Services/interfaces/IGraphClientService.cs
@@ -4,11 +4,11 @@ namespace EntraMfaPrefillinator.Lib.Services;
 
 public interface IGraphClientService
 {
-    Task<User> GetUserAsync(string userId);
-    Task<User> GetUserAsync(string userId, string? parentActivityId);
+    Task<User?> GetUserAsync(string userId);
+    Task<User?> GetUserAsync(string userId, string? parentActivityId);
 
-    Task<User> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber);
-    Task<User> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber, string? parentActivityId);
+    Task<User?> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber);
+    Task<User?> GetUserByUserNameAndEmployeeNumberAsync(string? userName, string? employeeNumber, string? parentActivityId);
 
     Task<PhoneAuthenticationMethod> AddPhoneAuthenticationMethodAsync(string userId, string phoneNumber);
     Task<PhoneAuthenticationMethod> AddPhoneAuthenticationMethodAsync(string userId, string phoneNumber, string? parentActivityId);


### PR DESCRIPTION
## Description

This PR fixes a null reference exception being thrown when calling Graph API methods in `GraphClientService` and, subsequently, causing `AuthUpdateApp` to hang during execution.

It was being caused by the error handling for the API calls:

https://github.com/Smalls1652/EntraMfaPrefillinator/blob/330e3adbf61209bb85b1e0f2d788d5dc2a43446f/src/Lib/Services/GraphClientService/Users/GetUserByUserNameAndEmployeeNumberAsync.cs#L79-L88

It took a bit to identify what was causing the null reference exception, because the stack trace pointed at a different call in the stack. Really the issue was in the "catch all" error handling that would deserialize the API response as if it was always a Graph API error response. That doesn't play nicely when the Graph API response is valid and an error is thrown elsewhere due to other issues.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None