### PR TITLE
Fix home phone number not being included in filter and delta checks

### DIFF
--- a/src/Tools/CsvImporter/Services/CsvFileReaderService/CsvFileReaderService.cs
+++ b/src/Tools/CsvImporter/Services/CsvFileReaderService/CsvFileReaderService.cs
@@ -91,7 +91,7 @@ public sealed class CsvFileReaderService : ICsvFileReaderService
 
             // If the user was found in the last run CSV file and the email or phone number has changed,
             // add the user to the delta list.
-            if (lastRunUserDetailsItem.PhoneNumber != userDetailsItem.PhoneNumber || lastRunUserDetailsItem.SecondaryEmail != userDetailsItem.SecondaryEmail)
+            if (lastRunUserDetailsItem.PhoneNumber != userDetailsItem.PhoneNumber || lastRunUserDetailsItem.SecondaryEmail != userDetailsItem.SecondaryEmail || lastRunUserDetailsItem.HomePhoneNumber != userDetailsItem.HomePhoneNumber)
             {
                 userDetailsItem.IsInLastRun = true;
                 deltaList.Add(userDetailsItem);

--- a/src/Tools/CsvImporter/Services/MainService/MainService.cs
+++ b/src/Tools/CsvImporter/Services/MainService/MainService.cs
@@ -146,7 +146,7 @@ public sealed class MainService : IMainService, IHostedService, IDisposable
 
 
             // Filter out users without an email or phone number set.
-            List<UserDetails> filteredUserDetailsList = userDetailsList.FindAll(userDetails => userDetails.SecondaryEmail is not null || userDetails.PhoneNumber is not null);
+            List<UserDetails> filteredUserDetailsList = userDetailsList.FindAll(userDetails => userDetails.SecondaryEmail is not null || userDetails.PhoneNumber is not null || userDetails.HomePhoneNumber is not null);
 
             activity?.SetTag("user.filtered.count", filteredUserDetailsList.Count);
             _logger.LogInformation("Filtered to {FilteredUserDetailsCount} users with email or phone number", filteredUserDetailsList.Count);


### PR DESCRIPTION
## Description

This PR fixes home phone numbers not being included in the filtered list and delta checks during the import.

### Type of change

- [ ] 🌟 New feature
- [ ] 💪 Enhancement
- [x] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None