### PR TITLE
Make CsvImporter a self-contained deployment

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -104,8 +104,8 @@
 			"problemMatcher": "$msCompile"
 		},
 		{
-			"label": "Compile project (Native AOT)",
-			"detail": "Compile a project with Native AOT.",
+			"label": "Publish project",
+			"detail": "Publish/compile a project.",
 			"icon": {
 				"id": "package",
 				"color": "terminal.ansiRed"
@@ -219,6 +219,22 @@
 			"description": "Select a configuration for compilation.",
 			"type": "pickString",
 			"default": "Debug",
+			"options": [
+				{
+					"label": "Debug",
+					"value": "Debug"
+				},
+				{
+					"label": "Release",
+					"value": "Release"
+				}
+			]
+		},
+        {
+			"id": "dotnetPublishConfiguration",
+			"description": "Select a configuration for compilation.",
+			"type": "pickString",
+			"default": "Release",
 			"options": [
 				{
 					"label": "Debug",

--- a/src/Hosting/Hosting.csproj
+++ b/src/Hosting/Hosting.csproj
@@ -19,6 +19,10 @@
     <RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+  <!-- Publish properties -->
+  <PropertyGroup>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
   <!-- Dependencies -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="all" />

--- a/src/Lib/Lib.csproj
+++ b/src/Lib/Lib.csproj
@@ -19,6 +19,10 @@
     <RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+  <!-- Publish properties -->
+  <PropertyGroup>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
   <!-- Additional settings -->
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/src/Tools/CsvImporter/CsvImporter.csproj
+++ b/src/Tools/CsvImporter/CsvImporter.csproj
@@ -22,14 +22,19 @@
   </PropertyGroup>
   <!-- Publish properties -->
   <PropertyGroup>
-    <PublishAot>true</PublishAot>
+    <PublishAot>false</PublishAot>
     <OptimizationPreference>Speed</OptimizationPreference>
+    <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>partial</TrimMode>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
   </PropertyGroup>
   <!-- Additional settings -->
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
   <!-- Dependencies -->
   <ItemGroup>
@@ -46,5 +51,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Lib\Lib.csproj" />
     <ProjectReference Include="..\..\Hosting\Hosting.csproj" />
+  </ItemGroup>
+  <!-- Trimming options -->
+  <ItemGroup>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

This PR makes `CsvImporter` a self-contained app, instead of Native AOT. There are some changes coming in the future for `CsvImporter` that aren't compatible with trimming in the Native AOT model. This might go back to being Native AOT if/when those changes are compatible.

It will still utilize trimming and not require the .NET runtime to be installed, but it won't be "natively compiled". Performance seems to be roughly the same.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None