### PR TITLE
Initial addition of CsvImporter.ConfigTool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           "./src/Lib.Azure",
           "./src/Hosting/",
           "./src/Tools/CsvImporter/",
+          "./src/Tools/CsvImporter.ConfigTool/",
           "./src/Tools/CsvImporter.Database/"
         ]
     env:

--- a/.github/workflows/csvimporter-create-artifacts.yml
+++ b/.github/workflows/csvimporter-create-artifacts.yml
@@ -43,7 +43,9 @@ jobs:
                 dotnet publish ./src/Tools/CsvImporter/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}";
                 Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.pdb" -Recurse -Force -Verbose;
                 Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dbg" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose
+                Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose;
+                dotnet publish ./src/Tools/CsvImporter.ConfigTool/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}";
+                Copy-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/entramfacsvimporter-config" -Destination "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/entramfacsvimporter-config" -Force -Verbose;
 
             - name: Create artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/csvimporter-create-artifacts.yml
+++ b/.github/workflows/csvimporter-create-artifacts.yml
@@ -19,6 +19,7 @@ jobs:
             runtime-identifier: [ linux-x64, linux-arm64, win-x64, win-arm64, osx-x64, osx-arm64 ]
         env:
             DOTNET_NOLOGO: true
+            IS_ARTIFACT_BUILD: true
         
         steps:
             - name: Checkout repository
@@ -41,21 +42,11 @@ jobs:
               shell: pwsh
               run: |
                 dotnet publish ./src/Tools/CsvImporter/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}";
-                Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.pdb" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dbg" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose;
-                dotnet publish ./src/Tools/CsvImporter.ConfigTool/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}";
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.pdb" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dbg" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dll" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dylib" -Recurse -Force -Verbose;
-                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.so" -Recurse -Force -Verbose;
-                Copy-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*" -Destination "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/" -Force -Verbose;
+                dotnet publish ./src/Tools/CsvImporter.ConfigTool/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}"
 
             - name: Create artifact
               uses: actions/upload-artifact@v4
               with:
                 name: "CsvImporter_${{ matrix.runtime-identifier }}_${{ github.ref_type == 'tag' && github.ref_name || github.sha }}"
-                path: ${{ github.workspace }}/artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/**/*
+                path: ${{ github.workspace }}/artifacts/publish/CsvImporterFull/release_${{ matrix.runtime-identifier }}/**/*
                 if-no-files-found: error

--- a/.github/workflows/csvimporter-create-artifacts.yml
+++ b/.github/workflows/csvimporter-create-artifacts.yml
@@ -45,7 +45,13 @@ jobs:
                 Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dbg" -Recurse -Force -Verbose;
                 Remove-Item -Path "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose;
                 dotnet publish ./src/Tools/CsvImporter.ConfigTool/ --configuration "Release" --runtime "${{ matrix.runtime-identifier }}";
-                Copy-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/entramfacsvimporter-config" -Destination "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/entramfacsvimporter-config" -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.pdb" -Recurse -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dbg" -Recurse -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dsym" -Recurse -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dll" -Recurse -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.dylib" -Recurse -Force -Verbose;
+                Remove-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*.so" -Recurse -Force -Verbose;
+                Copy-Item -Path "./artifacts/publish/CsvImporter.ConfigTool/release_${{ matrix.runtime-identifier }}/*" -Destination "./artifacts/publish/CsvImporter/release_${{ matrix.runtime-identifier }}/" -Force -Verbose;
 
             - name: Create artifact
               uses: actions/upload-artifact@v4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -302,6 +302,10 @@
         {
           "label": "CsvImporter.Database",
           "value": "src/Tools/CsvImporter.Database/"
+        },
+        {
+          "label": "CsvImporter.ConfigTool",
+          "value": "src/Tools/CsvImporter.ConfigTool/"
         }
       ]
     },
@@ -372,6 +376,10 @@
         {
           "label": "CsvImporter",
           "value": "src/Tools/CsvImporter"
+        },
+        {
+          "label": "CsvImporter.ConfigTool",
+          "value": "src/Tools/CsvImporter.ConfigTool"
         }
       ]
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.60.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
@@ -27,5 +28,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.6" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.24209.3" />
   </ItemGroup>
 </Project>

--- a/EntraMfaPrefillinator.sln
+++ b/EntraMfaPrefillinator.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvImporter.Database", "src\Tools\CsvImporter.Database\CsvImporter.Database.csproj", "{5EE841B5-3982-4FE9-8737-E287092DBD9C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvImporter.ConfigTool", "src\Tools\CsvImporter.ConfigTool\CsvImporter.ConfigTool.csproj", "{D4335382-BB08-4B22-96B5-5F8E5EC849B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{5EE841B5-3982-4FE9-8737-E287092DBD9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5EE841B5-3982-4FE9-8737-E287092DBD9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5EE841B5-3982-4FE9-8737-E287092DBD9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4335382-BB08-4B22-96B5-5F8E5EC849B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4335382-BB08-4B22-96B5-5F8E5EC849B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4335382-BB08-4B22-96B5-5F8E5EC849B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4335382-BB08-4B22-96B5-5F8E5EC849B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F96FD9F1-4FBB-4235-AE62-D7055DECC6AD} = {FC60D7C4-F0D8-4E64-BB51-416F222F5D1B}
@@ -59,5 +65,6 @@ Global
 		{B5F8BD80-AEDB-4F1B-AEA9-E53E0DF95310} = {33DE40FB-A917-4A86-AA79-5BAB5CC8E66A}
 		{AD068759-4FE6-44D0-BB5A-068131066D6F} = {FC60D7C4-F0D8-4E64-BB51-416F222F5D1B}
 		{5EE841B5-3982-4FE9-8737-E287092DBD9C} = {33DE40FB-A917-4A86-AA79-5BAB5CC8E66A}
+		{D4335382-BB08-4B22-96B5-5F8E5EC849B0} = {33DE40FB-A917-4A86-AA79-5BAB5CC8E66A}
 	EndGlobalSection
 EndGlobal

--- a/nuget.config
+++ b/nuget.config
@@ -5,10 +5,15 @@
     inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-dev-packages" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">
       <package pattern="*" />
+    </packageSource>
+    <packageSource key="dotnet-dev-packages">
+      <package pattern="System.CommandLine" />
+      <package pattern="System.CommandLine.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/src/Lib/Lib.csproj
+++ b/src/Lib/Lib.csproj
@@ -1,37 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<!-- Core properties -->
-	<PropertyGroup>
-		<RootNamespace>EntraMfaPrefillinator.Lib</RootNamespace>
-		<AssemblyName>EntraMfaPrefillinator.Lib</AssemblyName>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-	<!-- Package properties -->
-	<PropertyGroup>
-		<PackageId>EntraMfaPrefillinator.Lib</PackageId>
-		<Description>
-      Class library for EntraMfaPrefillinator.
-    </Description>
-		<Authors>Timothy Small</Authors>
-		<Company>Smalls.Online</Company>
-		<Copyright>© Smalls.Online</Copyright>
-		<RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
-	<!-- Publish properties -->
-	<PropertyGroup>
-		<IsTrimmable>true</IsTrimmable>
-	</PropertyGroup>
-	<!-- Additional settings -->
-	<PropertyGroup>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-	</PropertyGroup>
-	<!-- Dependencies -->
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Http" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Identity.Client" />
-	</ItemGroup>
+    <!-- Core properties -->
+    <PropertyGroup>
+        <RootNamespace>EntraMfaPrefillinator.Lib</RootNamespace>
+        <AssemblyName>EntraMfaPrefillinator.Lib</AssemblyName>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <!-- Package properties -->
+    <PropertyGroup>
+        <PackageId>EntraMfaPrefillinator.Lib</PackageId>
+        <Description>
+            Class library for EntraMfaPrefillinator.
+        </Description>
+        <Authors>Timothy Small</Authors>
+        <Company>Smalls.Online</Company>
+        <Copyright>© Smalls.Online</Copyright>
+        <RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <!-- Publish properties -->
+    <PropertyGroup>
+        <IsTrimmable>true</IsTrimmable>
+    </PropertyGroup>
+    <!-- Additional settings -->
+    <PropertyGroup>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    </PropertyGroup>
+    <!-- Dependencies -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.Http" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Identity.Client" />
+    </ItemGroup>
 </Project>

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommand.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommand.cs
@@ -1,0 +1,35 @@
+using System.CommandLine;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Commands;
+
+/// <summary>
+/// Command to reset the state for a user, so they can be reprocessed.
+/// </summary>
+public sealed class ResetUserCommand : CliCommand
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResetUserCommand"/> class.
+    /// </summary>
+    public ResetUserCommand() : base("reset-user")
+    {
+        Description = "Reset the state for a user, so they can be reprocessed.";
+
+        Options.Add(
+            new CliOption<string>("--employee-number")
+            {
+                Description = "The employee number of the user.",
+                Required = false
+            }
+        );
+
+        Options.Add(
+            new CliOption<string>("--username")
+            {
+                Description = "The username of the user.",
+                Required = false
+            }
+        );
+
+        Action = new ResetUserCommandAction();
+    }
+}

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandAction.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandAction.cs
@@ -1,0 +1,67 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+using EntraMfaPrefillinator.Lib.Models;
+using EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Utilities;
+using EntraMfaPrefillinator.Tools.CsvImporter.Database.Contexts;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Commands;
+
+/// <summary>
+/// Action for the 'reset-user' command.
+/// </summary>
+public sealed class ResetUserCommandAction : AsynchronousCliAction
+{
+    /// <inheritdoc />
+    public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
+    {
+        using ILoggerFactory loggerFactory = LoggerUtilities.CreateLoggerFactory();
+        ILogger logger = loggerFactory.CreateLogger("Reset User Command");
+
+        // Parse the options passed to the command.
+        RootCommandOptions rootOptions;
+        ResetUserCommandOptions options;
+        try
+        {
+            rootOptions = new RootCommandOptions(parseResult);
+            options = new ResetUserCommandOptions(parseResult);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to parse command options.");
+            return 1;
+        }
+
+        // Connect to the database and find the user.
+        using UserDetailsDbContext dbContext = new(
+            options: new DbContextOptionsBuilder<UserDetailsDbContext>()
+                .UseSqlite($"Data Source={rootOptions.DatabasePath}")
+                .Options
+        );
+
+        UserDetails? user = options.EmployeeNumber is not null
+            ? await dbContext.UserDetails
+                .FirstOrDefaultAsync(item => item.EmployeeNumber == options.EmployeeNumber, cancellationToken)
+            : await dbContext.UserDetails
+                .FirstOrDefaultAsync(item => item.UserName == options.Username, cancellationToken);
+
+        if (user is null)
+        {
+            logger.LogWarning("User not found.");
+            return 1;
+        }
+
+        logger.LogInformation("Resetting state for '{userName}' ({employeeNumber}).", user.UserName, user.EmployeeNumber);
+
+        // Remove the user from the database and save the changes.
+        dbContext.UserDetails.Remove(user);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        
+        logger.LogInformation("User state reset.");
+
+        return 0;
+    }
+}

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
@@ -1,0 +1,55 @@
+using System.CommandLine;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Commands;
+
+/// <summary>
+/// Options for the 'reset-user' command.
+/// </summary>
+public sealed class ResetUserCommandOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResetUserCommandOptions"/> class.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    /// <exception cref="InvalidOperationException">Thrown when '--employee-number' and '--username' are both null.</exception>
+    public ResetUserCommandOptions(ParseResult parseResult)
+    {
+        EmployeeNumber = ParseEmployeeNumberOption(parseResult);
+        Username = ParseUsernameOption(parseResult);
+
+        if (EmployeeNumber is null && Username is null || string.IsNullOrEmpty(EmployeeNumber) && string.IsNullOrEmpty(Username))
+        {
+            throw new InvalidOperationException("Either --employee-number or --username must be specified.");
+        }
+    }
+
+    /// <summary>
+    /// The employee number of the user.
+    /// </summary>
+    public string? EmployeeNumber { get; set; }
+
+    /// <summary>
+    /// The username of the user.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Parses the '--employee-number' option.
+    /// </summary>
+    /// <param name="parseResult">The parse result.</param>
+    /// <returns>The value of the '--employee-number' option.</returns>
+    private static string? ParseEmployeeNumberOption(ParseResult parseResult)
+    {
+        return parseResult.GetValue<string>("--employee-number");
+    }
+
+    /// <summary>
+    /// Parses the '--username' option.
+    /// </summary>
+    /// <param name="parseResult">The parse result.</param>
+    /// <returns>The value of the '--username' option.</returns>
+    private static string? ParseUsernameOption(ParseResult parseResult)
+    {
+        return parseResult.GetValue<string>("--username");
+    }
+}

--- a/src/Tools/CsvImporter.ConfigTool/CsvImporter.ConfigTool.csproj
+++ b/src/Tools/CsvImporter.ConfigTool/CsvImporter.ConfigTool.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<!-- Core properties -->
+	<PropertyGroup>
+		<RootNamespace>EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool</RootNamespace>
+		<AssemblyName>entramfacsvimporter-config</AssemblyName>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<!-- Package properties -->
+	<PropertyGroup>
+		<PackageId>EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool</PackageId>
+		<Description>
+            CLI tool for configuring/maintaining the EntraMfaPrefillinator CSV importer.
+        </Description>
+		<Authors>Timothy Small</Authors>
+		<Company>Smalls.Online</Company>
+		<Copyright>© 2024 Smalls.Online</Copyright>
+		<RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+	<!-- Publish properties -->
+	<PropertyGroup>
+		<PublishSingleFile>true</PublishSingleFile>
+		<SelfContained>true</SelfContained>
+		<PublishTrimmed>true</PublishTrimmed>
+		<TrimMode>partial</TrimMode>
+		<CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+	</PropertyGroup>
+	<!-- Additional settings -->
+	<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+	</PropertyGroup>
+	<!-- Dependencies -->
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" />
+		<PackageReference Include="System.CommandLine" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\CsvImporter.Database\CsvImporter.Database.csproj" />
+		<ProjectReference Include="..\..\Lib\Lib.csproj" />
+	</ItemGroup>
+    <!-- Trimming options -->
+    <ItemGroup>
+        <TrimmerRootAssembly Include="entramfacsvimporter-config" />
+        <TrimmableAssembly Include="Microsoft.Extensions.Logging" />
+        <TrimmableAssembly Include="Microsoft.Extensions.Logging.Console" />
+        <TrimmableAssembly Include="System.CommandLine" />
+        <TrimmableAssembly Include="EntraMfaPrefillinator.Lib" />
+    </ItemGroup>
+</Project>

--- a/src/Tools/CsvImporter.ConfigTool/CsvImporter.ConfigTool.csproj
+++ b/src/Tools/CsvImporter.ConfigTool/CsvImporter.ConfigTool.csproj
@@ -51,4 +51,30 @@
         <TrimmableAssembly Include="System.CommandLine" />
         <TrimmableAssembly Include="EntraMfaPrefillinator.Lib" />
     </ItemGroup>
+    <!-- Custom targets -->
+    <Target Name="CopyToCombinedOutput">
+        <PropertyGroup>
+            <CsvImporterConfigTool_PublishedPath>$(ArtifactsPath)\publish\CsvImporter.ConfigTool\$(Configuration.ToLower())_$(RuntimeIdentifier)</CsvImporterConfigTool_PublishedPath>
+            <CsvImporter_CombinedOutputPath>$(ArtifactsPath)\publish\CsvImporterFull\$(Configuration.ToLower())_$(RuntimeIdentifier)\</CsvImporter_CombinedOutputPath>
+        </PropertyGroup>
+        <ItemGroup>
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporterConfigTool_PublishedPath)\entramfacsvimporter-config.exe"
+              Condition="'$(RuntimeIdentifier)'=='win-x64' Or '$(RuntimeIdentifier)'=='win-arm64'" />
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporterConfigTool_PublishedPath)\entramfacsvimporter-config"
+              Condition="'$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'" />
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporterConfigTool_PublishedPath)\entramfacsvimporter-config"
+              Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'" />
+        </ItemGroup>
+        <MakeDir Directories="$(CsvImporter_CombinedOutputPath)" />
+        <Copy
+            SourceFiles="@(CsvImporter_FilesToCopy)"
+            DestinationFolder="$(CsvImporter_CombinedOutputPath)" />
+    </Target>
+    <Target Name="CopyToCombinedOutput_AfterPublish" AfterTargets="Publish" Condition="'$(IS_ARTIFACT_BUILD)'=='true'">
+        <Message Importance="high" Text="CsvImporter.ConfigTool -&gt; Copying to combined output..." />
+        <CallTarget Targets="CopyToCombinedOutput" />
+    </Target>
 </Project>

--- a/src/Tools/CsvImporter.ConfigTool/Program.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Program.cs
@@ -1,0 +1,9 @@
+﻿using System.CommandLine;
+
+using EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool;
+
+CliConfiguration cliConfig = new(
+    rootCommand: new RootCommand()
+);
+
+return await cliConfig.InvokeAsync(args);

--- a/src/Tools/CsvImporter.ConfigTool/RootCommand.cs
+++ b/src/Tools/CsvImporter.ConfigTool/RootCommand.cs
@@ -1,0 +1,42 @@
+using System.CommandLine;
+
+using EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Commands;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool;
+
+/// <summary>
+/// The base root command for the CsvImporter Config Tool.
+/// </summary>
+public sealed class RootCommand : CliRootCommand
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RootCommand"/> class.
+    /// </summary>
+    public RootCommand() : base("EntraMfaPrefillinator CSV Importer Config Tool")
+    {
+        string configDirPath = Path.Combine(
+            path1: Environment.IsPrivilegedProcess
+                ? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
+                : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            path2: "EntraMfaPrefillinator",
+            path3: "CsvImporter"
+        );
+
+        string defaultDbPath = Path.Combine(
+            path1: configDirPath,
+            path2: "CsvImporter.sqlite"
+        );
+
+        Options.Add(
+            new CliOption<string>("--database-path")
+            {
+                Description = "The file path to the SQLite database.",
+                Required = true,
+                Recursive = true,
+                DefaultValueFactory = (_) => defaultDbPath
+            }
+        );
+
+        Add(new ResetUserCommand());
+    }
+}

--- a/src/Tools/CsvImporter.ConfigTool/RootCommandOptions.cs
+++ b/src/Tools/CsvImporter.ConfigTool/RootCommandOptions.cs
@@ -1,0 +1,34 @@
+using System.CommandLine;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool;
+
+/// <summary>
+/// Options for the root command.
+/// </summary>
+public sealed class RootCommandOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RootCommandOptions"/> class.
+    /// </summary>
+    /// <param name="parseResult">The parse result from the command line.</param>
+    public RootCommandOptions(ParseResult parseResult)
+    {
+        DatabasePath = ParseDatabasePathOption(parseResult);
+    }
+
+    /// <summary>
+    /// The file path to the SQLite database.
+    /// </summary>
+    public string DatabasePath { get; set; }
+
+    /// <summary>
+    /// Parses the '--database-path' option.
+    /// </summary>
+    /// <param name="parseResult">The parse result.</param>
+    /// <returns>The value of the '--database-path' option.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when '--database-path' is null.</exception>
+    private static string ParseDatabasePathOption(ParseResult parseResult)
+    {
+        return parseResult.GetValue<string>("--database-path") ?? throw new InvalidOperationException("--database-path is required.");
+    }
+}

--- a/src/Tools/CsvImporter.ConfigTool/Utilities/LoggerUtilities.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Utilities/LoggerUtilities.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+
+namespace EntraMfaPrefillinator.Tools.CsvImporter.ConfigTool.Utilities;
+
+/// <summary>
+/// Utility methods for creating loggers.
+/// </summary>
+public static class LoggerUtilities
+{
+    /// <summary>
+    /// Creates an <see cref="ILoggerFactory"/> with a simple console logger.
+    /// </summary>
+    /// <returns>The logger factory.</returns>
+    public static ILoggerFactory CreateLoggerFactory()
+    {
+        return LoggerFactory.Create(configure =>
+        {
+            configure.AddSimpleConsole(options =>
+            {
+                options.IncludeScopes = false;
+                options.SingleLine = false;
+            });
+
+            configure.AddFilter("Default", LogLevel.Information);
+        });
+    }
+}

--- a/src/Tools/CsvImporter.Database/CsvImporter.Database.csproj
+++ b/src/Tools/CsvImporter.Database/CsvImporter.Database.csproj
@@ -1,49 +1,49 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<!-- Core properties -->
-	<PropertyGroup>
-		<RootNamespace>EntraMfaPrefillinator.Tools.CsvImporter.Database</RootNamespace>
-		<AssemblyName>EntraMfaPrefillinator.Tools.CsvImporter.Database</AssemblyName>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-	<!-- Package properties -->
-	<PropertyGroup>
-		<PackageId>EntraMfaPrefillinator.Tools.CsvImporter.Database</PackageId>
-		<Description>
-      EF Core class library for the EntraMfaPrefillinator CSV importer.
-    </Description>
-		<Authors>Timothy Small</Authors>
-		<Company>Smalls.Online</Company>
-		<Copyright>© 2024 Smalls.Online</Copyright>
-		<RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
-	<!-- Publish properties -->
-	<PropertyGroup>
-		<IsTrimmable>false</IsTrimmable>
-	</PropertyGroup>
-	<!-- Additional settings -->
-	<PropertyGroup>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-		<EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-	</PropertyGroup>
-	<!-- Dependencies -->
-	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" PrivateAssets="all" />
-		<PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all"/>
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\Lib\Lib.csproj" />
-	</ItemGroup>
+    <!-- Core properties -->
+    <PropertyGroup>
+        <RootNamespace>EntraMfaPrefillinator.Tools.CsvImporter.Database</RootNamespace>
+        <AssemblyName>EntraMfaPrefillinator.Tools.CsvImporter.Database</AssemblyName>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <!-- Package properties -->
+    <PropertyGroup>
+        <PackageId>EntraMfaPrefillinator.Tools.CsvImporter.Database</PackageId>
+        <Description>
+            EF Core class library for the EntraMfaPrefillinator CSV importer.
+        </Description>
+        <Authors>Timothy Small</Authors>
+        <Company>Smalls.Online</Company>
+        <Copyright>© 2024 Smalls.Online</Copyright>
+        <RepositoryUrl>https://github.com/Smalls1652/EntraMfaPrefillinator</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <!-- Publish properties -->
+    <PropertyGroup>
+        <IsTrimmable>false</IsTrimmable>
+    </PropertyGroup>
+    <!-- Additional settings -->
+    <PropertyGroup>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    </PropertyGroup>
+    <!-- Dependencies -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Extensions.Logging" PrivateAssets="all" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Lib\Lib.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/Tools/CsvImporter/CsvImporter.csproj
+++ b/src/Tools/CsvImporter/CsvImporter.csproj
@@ -54,5 +54,30 @@
         <ProjectReference Include="..\..\Lib\Lib.csproj" />
         <ProjectReference Include="..\..\Lib.Azure\Lib.Azure.csproj" />
     </ItemGroup>
-    <!-- Trimming options -->
+    <!-- Custom targets -->
+    <Target Name="CopyToCombinedOutput">
+        <PropertyGroup>
+            <CsvImporter_PublishedPath>$(ArtifactsPath)\publish\CsvImporter\$(Configuration.ToLower())_$(RuntimeIdentifier)</CsvImporter_PublishedPath>
+            <CsvImporter_CombinedOutputPath>$(ArtifactsPath)\publish\CsvImporterFull\$(Configuration.ToLower())_$(RuntimeIdentifier)\</CsvImporter_CombinedOutputPath>
+        </PropertyGroup>
+        <ItemGroup>
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporter_PublishedPath)\entramfacsvimporter.exe;$(CsvImporter_PublishedPath)\e_sqlite3.dll"
+              Condition="'$(RuntimeIdentifier)'=='win-x64' Or '$(RuntimeIdentifier)'=='win-arm64'" />
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporter_PublishedPath)\entramfacsvimporter;$(CsvImporter_PublishedPath)\libe_sqlite3.so"
+              Condition="'$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'" />
+            <CsvImporter_FilesToCopy 
+              Include="$(CsvImporter_PublishedPath)\entramfacsvimporter;$(CsvImporter_PublishedPath)\libe_sqlite3.dylib"
+              Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'" />
+        </ItemGroup>
+        <MakeDir Directories="$(CsvImporter_CombinedOutputPath)" />
+        <Copy
+            SourceFiles="@(CsvImporter_FilesToCopy)"
+            DestinationFolder="$(CsvImporter_CombinedOutputPath)" />
+    </Target>
+    <Target Name="CopyToCombinedOutput_AfterPublish" AfterTargets="Publish" Condition="'$(IS_ARTIFACT_BUILD)'=='true'">
+        <Message Importance="high" Text="CsvImporter -&gt; Copying to combined output..." />
+        <CallTarget Targets="CopyToCombinedOutput" />
+    </Target>
 </Project>


### PR DESCRIPTION
## Description

This PR adds a dedicated config CLI tool for `CsvImporter`. It currently only has the ability to reset the state of a user in the database, but it will be expanded on in the future.

### Type of change

- [x] 🌟 New feature
- [ ] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None