### PR TITLE
Treat home phone number as mobile and use home phone number as alternate

### DIFF
--- a/src/AuthUpdateApp/Extensions/Telemetry/Activities/UserAuthUpdateActivityExtensions.cs
+++ b/src/AuthUpdateApp/Extensions/Telemetry/Activities/UserAuthUpdateActivityExtensions.cs
@@ -72,6 +72,19 @@ internal static class UserAuthUpdateActivityExtensions
     }
 
     /// <summary>
+    /// Add a tag to an activity that indicates whether the request
+    /// includes an alternative phone number.
+    /// </summary>
+    /// <param name="activity">The <see cref="Activity"/> to add the tag to.</param>
+    /// <param name="phoneAuthMethodIncluded">Whether the request includes a phone number.</param>
+    /// <returns>The modified <see cref="Activity"/>.</returns>
+    public static Activity? AddUserAlternatePhoneAuthMethodIncludedInRequestTag(this Activity? activity, bool phoneAuthMethodIncluded)
+    {
+        return activity?
+            .AddTag("user.auth.alternatePhone.includedInRequest", phoneAuthMethodIncluded);
+    }
+
+    /// <summary>
     /// Add a tag to an activity that indicates whether the user has an existing
     /// email auth method.
     /// </summary>
@@ -95,6 +108,19 @@ internal static class UserAuthUpdateActivityExtensions
     {
         return activity?
             .AddTag("user.auth.phone.hasExisting", hasPhoneAuthMethod);
+    }
+
+    /// <summary>
+    /// Add a tag to an activity that indicates whether the user has an existing
+    /// alternative phone auth method.
+    /// </summary>
+    /// <param name="activity">The <see cref="Activity"/> to add the tag to.</param>
+    /// <param name="hasPhoneAuthMethod">Whether the user has an existing phone auth method.</param>
+    /// <returns>The modified <see cref="Activity"/>.</returns>
+    public static Activity? AddUserHasExisitingAlternatePhoneAuthMethodTag(this Activity? activity, bool hasPhoneAuthMethod)
+    {
+        return activity?
+            .AddTag("user.auth.alternatePhone.hasExisting", hasPhoneAuthMethod);
     }
 
     /// <summary>
@@ -125,6 +151,19 @@ internal static class UserAuthUpdateActivityExtensions
 
     /// <summary>
     /// Add a tag to an activity that indicates whether an
+    /// alternative phone auth method was added to the user during the process.
+    /// </summary>
+    /// <param name="activity">The <see cref="Activity"/> to add the tag to.</param>
+    /// <param name="phoneAuthMethodAdded">Whether a phone auth method was added.</param>
+    /// <returns>The modified <see cref="Activity"/>.</returns>
+    public static Activity? AddUserHadAlternatePhoneAuthMethodAddedTag(this Activity? activity, bool phoneAuthMethodAdded)
+    {
+        return activity?
+            .AddTag("user.auth.alternatePhone.added", phoneAuthMethodAdded);
+    }
+
+    /// <summary>
+    /// Add a tag to an activity that indicates whether an
     /// email auth method wasn't added to the user during the process
     /// because the app is in "dry run" mode.
     /// </summary>
@@ -149,5 +188,19 @@ internal static class UserAuthUpdateActivityExtensions
     {
         return activity?
             .AddTag("user.auth.phone.dryRun", isDryRun);
+    }
+
+    /// <summary>
+    /// Add a tag to an activity that indicates whether an
+    /// alternative phone auth method wasn't added to the user during the process
+    /// because the app is in "dry run" mode.
+    /// </summary>
+    /// <param name="activity">The <see cref="Activity"/> to add the tag to.</param>
+    /// <param name="isDryRun">Whether the app is in "dry run" mode.</param>
+    /// <returns>The modified <see cref="Activity"/>.</returns>
+    public static Activity? AddUserAlternatePhoneAuthUpdateDryRunTag(this Activity? activity, bool isDryRun)
+    {
+        return activity?
+            .AddTag("user.auth.alternatePhone.dryRun", isDryRun);
     }
 }

--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -255,18 +255,18 @@ internal sealed class MainService : IHostedService, IDisposable
                     activity?.AddUserHasExisitingPhoneAuthMethodTag(false);
                     try
                     {
-                        await _graphClientService.AddOfficePhoneAuthenticationMethodAsync(
+                        await _graphClientService.AddPhoneAuthenticationMethodAsync(
                             userId: user.Id,
                             phoneNumber: queueItem.HomePhone
                         );
 
-                        _logger.LogInformation("Added office phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
+                        _logger.LogInformation("Added home phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
                         activity?.AddUserHadPhoneAuthMethodAddedTag(true);
                         activity?.AddUserPhoneAuthUpdateDryRunTag(false);
                     }
                     catch (GraphClientDryRunException)
                     {
-                        _logger.LogWarning("Dry run is enabled. Skipping adding office phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
+                        _logger.LogWarning("Dry run is enabled. Skipping adding home phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
                         activity?.AddUserPhoneAuthUpdateDryRunTag(true);
                     }
                     catch (Exception)

--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -207,7 +207,11 @@ internal sealed class MainService : IHostedService, IDisposable
                 activity?.AddUserPhoneAuthMethodIncludedInRequestTag(true);
                 PhoneAuthenticationMethod[]? phoneAuthMethods = await _graphClientService.GetPhoneAuthenticationMethodsAsync(user.Id, activity?.Id);
 
-                if (phoneAuthMethods is not null && phoneAuthMethods.Length != 0)
+                PhoneAuthenticationMethod[]? mobilePhoneAuthMethods = phoneAuthMethods is not null
+                    ? Array.FindAll(phoneAuthMethods, item => item.PhoneType == "mobile")
+                    : null;
+
+                if (mobilePhoneAuthMethods is not null && mobilePhoneAuthMethods.Length != 0)
                 {
                     _logger.LogWarning("'{userPrincipalName}' already has phone auth methods configured. Skipping...", user.UserPrincipalName);
                     activity?.AddUserHasExisitingPhoneAuthMethodTag(true);
@@ -245,7 +249,11 @@ internal sealed class MainService : IHostedService, IDisposable
                 activity?.AddUserPhoneAuthMethodIncludedInRequestTag(true);
                 PhoneAuthenticationMethod[]? phoneAuthMethods = await _graphClientService.GetPhoneAuthenticationMethodsAsync(user.Id, activity?.Id);
 
-                if (phoneAuthMethods is not null && phoneAuthMethods.Length != 0)
+                PhoneAuthenticationMethod[]? mobilePhoneAuthMethods = phoneAuthMethods is not null
+                    ? Array.FindAll(phoneAuthMethods, item => item.PhoneType == "mobile")
+                    : null;
+
+                if (mobilePhoneAuthMethods is not null && mobilePhoneAuthMethods.Length != 0)
                 {
                     _logger.LogWarning("'{userPrincipalName}' already has phone auth methods configured. Skipping...", user.UserPrincipalName);
                     activity?.AddUserHasExisitingPhoneAuthMethodTag(true);
@@ -282,6 +290,50 @@ internal sealed class MainService : IHostedService, IDisposable
             {
                 _logger.LogWarning("'{userPrincipalName}' did not have a phone number supplied in the request. Skipping...", user.UserPrincipalName);
                 activity?.AddUserPhoneAuthMethodIncludedInRequestTag(false);
+            }
+
+            if (queueItem.PhoneNumber is not null && queueItem.HomePhone is not null)
+            {
+                activity?.AddUserAlternatePhoneAuthMethodIncludedInRequestTag(true);
+
+                PhoneAuthenticationMethod[]? phoneAuthMethods = await _graphClientService.GetPhoneAuthenticationMethodsAsync(user.Id, activity?.Id);
+
+                PhoneAuthenticationMethod[]? alternateMobilePhoneAuthMethods = phoneAuthMethods is not null
+                    ? Array.FindAll(phoneAuthMethods, item => item.PhoneType == "alternateMobile")
+                    : null;
+
+                if (alternateMobilePhoneAuthMethods is not null && alternateMobilePhoneAuthMethods.Length != 0)
+                {
+                    _logger.LogWarning("'{userPrincipalName}' already has alternate phone auth methods configured. Skipping...", user.UserPrincipalName);
+                    activity?.AddUserHasExisitingAlternatePhoneAuthMethodTag(true);
+                }
+                else
+                {
+                    activity?.AddUserHasExisitingAlternatePhoneAuthMethodTag(false);
+                    try
+                    {
+                        await _graphClientService.AddAlternatePhoneAuthenticationMethodAsync(
+                            userId: user.Id,
+                            phoneNumber: queueItem.HomePhone
+                        );
+
+                        _logger.LogInformation("Added alternate phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
+                        activity?.AddUserHadAlternatePhoneAuthMethodAddedTag(true);
+                        activity?.AddUserAlternatePhoneAuthUpdateDryRunTag(false);
+                    }
+                    catch (GraphClientDryRunException)
+                    {
+                        _logger.LogWarning("Dry run is enabled. Skipping adding alternate phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
+                        activity?.AddUserAlternatePhoneAuthUpdateDryRunTag(true);
+                    }
+                    catch (Exception)
+                    {
+                        //_logger.LogError(ex, "Error adding alternate phone auth method for '{userPrincipalName}'.", user.UserPrincipalName);
+                        //activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                        //errorOccurred = true;
+                        throw;
+                    }
+                }
             }
 
             return;

--- a/src/Lib/Services/GraphClientService/AuthenticationMethods/AddAlternatePhoneAuthenticationMethodAsync.cs
+++ b/src/Lib/Services/GraphClientService/AuthenticationMethods/AddAlternatePhoneAuthenticationMethodAsync.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using EntraMfaPrefillinator.Lib.Models.Graph;
+
+namespace EntraMfaPrefillinator.Lib.Services;
+
+public partial class GraphClientService
+{
+    public async Task<PhoneAuthenticationMethod> AddAlternatePhoneAuthenticationMethodAsync(string userId, string phoneNumber) => await AddAlternatePhoneAuthenticationMethodAsync(userId, phoneNumber, null);
+    public async Task<PhoneAuthenticationMethod> AddAlternatePhoneAuthenticationMethodAsync(string userId, string phoneNumber, string? parentActivityId)
+    {
+        using var activity = _activitySource.StartActivity(
+            name: "AddAlternatePhoneAuthenticationMethodAsync",
+            kind: ActivityKind.Client,
+            tags: new ActivityTagsCollection
+            {
+                { "userId", userId }
+            },
+            parentId: parentActivityId
+        );
+
+        if (_disableUpdateMethods)
+        {
+            activity?.SetStatus(ActivityStatusCode.Ok, "Dry run mode is enabled.");
+            throw new GraphClientDryRunException("AddAlternatePhoneAuthenticationMethodAsync() was called, but the service is currently configured to disable update methods.");
+        }
+
+        string apiEndpoint = $"users/{userId}/authentication/phoneMethods";
+
+        PhoneAuthenticationMethod newPhoneAuthMethod = new()
+        {
+            PhoneNumber = phoneNumber,
+            PhoneType = "alternateMobile"
+        };
+
+        string apiResultString = await SendApiCallAsync(
+            endpoint: apiEndpoint,
+            httpMethod: HttpMethod.Post,
+            body: JsonSerializer.Serialize(
+                value: newPhoneAuthMethod,
+                jsonTypeInfo: GraphJsonContext.Default.PhoneAuthenticationMethod
+            )
+        ) ?? throw new Exception("API result was null.");
+
+        PhoneAuthenticationMethod phoneAuthMethod;
+        try
+        {
+            phoneAuthMethod = JsonSerializer.Deserialize(
+                json: apiResultString,
+                jsonTypeInfo: GraphJsonContext.Default.PhoneAuthenticationMethod
+            )!;
+
+            return phoneAuthMethod;
+        }
+        catch (ArgumentNullException)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+        catch (JsonException)
+        {
+            try
+            {
+                GraphErrorResponse? errorResponse = JsonSerializer.Deserialize(
+                    json: apiResultString,
+                    jsonTypeInfo: GraphJsonContext.Default.GraphErrorResponse
+                );
+
+                activity?.SetStatus(ActivityStatusCode.Error, errorResponse?.Error?.Message ?? "Unknown error.");
+                throw new Exception(errorResponse!.Error!.Message);
+            }
+            catch (JsonException)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+                throw new Exception("An unknown error occurred.");
+            }
+            throw;
+        }
+        catch (Exception)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error);
+            throw;
+        }
+    }
+}

--- a/src/Lib/Services/interfaces/IGraphClientService.cs
+++ b/src/Lib/Services/interfaces/IGraphClientService.cs
@@ -13,6 +13,9 @@ public interface IGraphClientService
     Task<PhoneAuthenticationMethod> AddPhoneAuthenticationMethodAsync(string userId, string phoneNumber);
     Task<PhoneAuthenticationMethod> AddPhoneAuthenticationMethodAsync(string userId, string phoneNumber, string? parentActivityId);
 
+    Task<PhoneAuthenticationMethod> AddAlternatePhoneAuthenticationMethodAsync(string userId, string phoneNumber);
+    Task<PhoneAuthenticationMethod> AddAlternatePhoneAuthenticationMethodAsync(string userId, string phoneNumber, string? parentActivityId);
+
     Task<PhoneAuthenticationMethod> AddOfficePhoneAuthenticationMethodAsync(string userId, string phoneNumber);
     Task<PhoneAuthenticationMethod> AddOfficePhoneAuthenticationMethodAsync(string userId, string phoneNumber, string? parentActivityId);
 


### PR DESCRIPTION
## Description

This PR changes how home phone numbers are added.

**If no _"mobile number"_ is provided**, it will just be treated as a mobile number.

**If a _"mobile number"_ AND _"home number"_ are provided**, the home number will be added as an alternate mobile number.

### Type of change

- [x] 🌟 New feature
- [ ] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None