### PR TITLE
Remove the GetAndProcessQueueMessages activity

### DIFF
--- a/src/AuthUpdateApp/Services/MainService/MainService.cs
+++ b/src/AuthUpdateApp/Services/MainService/MainService.cs
@@ -46,12 +46,6 @@ internal sealed class MainService : IHostedService, IDisposable
     /// <returns></returns>
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
-        using Activity? activity = _activitySource
-            .StartActivity(
-                name: "GetAndProcessQueueMessages",
-                kind: ActivityKind.Internal
-            );
-
         _logger.LogInformation("Getting messages from queue...");
 
         NullableResponse<QueueMessage[]> queueMessages = await _queueClientService.AuthUpdateQueueClient.ReceiveMessagesAsync(
@@ -89,8 +83,6 @@ internal sealed class MainService : IHostedService, IDisposable
         {
             _logger.LogError(ex, "An error occurred while processing queue messages.");
         }
-
-        activity?.SetStatus(ActivityStatusCode.Ok);
 
         _appLifetime.StopApplication();
     }


### PR DESCRIPTION
## Description

* Much like in PR #91, this activity pollutes the telemetry data as it still gets correlated to the child activities.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None