### PR TITLE
Add multi-user support for resetting state

### DIFF
--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommand.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommand.cs
@@ -15,7 +15,7 @@ public sealed class ResetUserCommand : CliCommand
         Description = "Reset the state for a user, so they can be reprocessed.";
 
         Options.Add(
-            new CliOption<string>("--employee-number")
+            new CliOption<string[]>("--employee-number")
             {
                 Description = "The employee number of the user.",
                 Required = false
@@ -23,7 +23,7 @@ public sealed class ResetUserCommand : CliCommand
         );
 
         Options.Add(
-            new CliOption<string>("--username")
+            new CliOption<string[]>("--username")
             {
                 Description = "The username of the user.",
                 Required = false

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandAction.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandAction.cs
@@ -42,9 +42,9 @@ public sealed class ResetUserCommandAction : AsynchronousCliAction
                 .Options
         );
 
+        //Get the user details from the database.
         List<UserDetails> userDetails = [];
-
-        if (options.EmployeeNumber is not null && options.EmployeeNumber.Length > 0)
+        if (options.EmployeeNumber.Length > 0)
         {
             foreach (string employeeNumber in options.EmployeeNumber)
             {
@@ -61,7 +61,7 @@ public sealed class ResetUserCommandAction : AsynchronousCliAction
                 }
             }
         }
-        else if (options.Username is not null && options.Username.Length > 0)
+        else if (options.Username.Length > 0)
         {
             foreach (string username in options.Username)
             {
@@ -84,12 +84,14 @@ public sealed class ResetUserCommandAction : AsynchronousCliAction
             return 1;
         }
 
+        // If no users were found, log an error and return.
         if (userDetails.Count == 0)
         {
             logger.LogError("No users found.");
             return 1;
         }
 
+        // Reset the state for each user.
         foreach (UserDetails user in userDetails)
         {
             logger.LogInformation("Resetting state for '{UserName}' ({EmployeeNumber}).", user.UserName, user.EmployeeNumber);

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
@@ -17,30 +17,35 @@ public sealed class ResetUserCommandOptions
         EmployeeNumber = ParseEmployeeNumberOption(parseResult);
         Username = ParseUsernameOption(parseResult);
 
-        if (EmployeeNumber is null && Username is null || EmployeeNumber?.Length == 0 && Username?.Length == 0)
+        if (EmployeeNumber.Length == 0 || Username.Length == 0)
         {
             throw new InvalidOperationException("Either --employee-number or --username must be specified.");
+        }
+
+        if (EmployeeNumber.Length > 0 && Username.Length > 0)
+        {
+            throw new InvalidOperationException("--employee-number and --username can't be specified together.");
         }
     }
 
     /// <summary>
     /// The employee number of the user.
     /// </summary>
-    public string[]? EmployeeNumber { get; set; }
+    public string[] EmployeeNumber { get; set; }
 
     /// <summary>
     /// The username of the user.
     /// </summary>
-    public string[]? Username { get; set; }
+    public string[] Username { get; set; }
 
     /// <summary>
     /// Parses the '--employee-number' option.
     /// </summary>
     /// <param name="parseResult">The parse result.</param>
     /// <returns>The value of the '--employee-number' option.</returns>
-    private static string[]? ParseEmployeeNumberOption(ParseResult parseResult)
+    private static string[] ParseEmployeeNumberOption(ParseResult parseResult)
     {
-        return parseResult.GetValue<string[]>("--employee-number");
+        return parseResult.GetValue<string[]>("--employee-number") ?? [];
     }
 
     /// <summary>
@@ -48,8 +53,8 @@ public sealed class ResetUserCommandOptions
     /// </summary>
     /// <param name="parseResult">The parse result.</param>
     /// <returns>The value of the '--username' option.</returns>
-    private static string[]? ParseUsernameOption(ParseResult parseResult)
+    private static string[] ParseUsernameOption(ParseResult parseResult)
     {
-        return parseResult.GetValue<string[]>("--username");
+        return parseResult.GetValue<string[]>("--username") ?? [];
     }
 }

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
@@ -17,7 +17,7 @@ public sealed class ResetUserCommandOptions
         EmployeeNumber = ParseEmployeeNumberOption(parseResult);
         Username = ParseUsernameOption(parseResult);
 
-        if (EmployeeNumber.Length == 0 || Username.Length == 0)
+        if (EmployeeNumber.Length == 0 && Username.Length == 0)
         {
             throw new InvalidOperationException("Either --employee-number or --username must be specified.");
         }

--- a/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
+++ b/src/Tools/CsvImporter.ConfigTool/Commands/ResetUserCommand/ResetUserCommandOptions.cs
@@ -17,7 +17,7 @@ public sealed class ResetUserCommandOptions
         EmployeeNumber = ParseEmployeeNumberOption(parseResult);
         Username = ParseUsernameOption(parseResult);
 
-        if (EmployeeNumber is null && Username is null || string.IsNullOrEmpty(EmployeeNumber) && string.IsNullOrEmpty(Username))
+        if (EmployeeNumber is null && Username is null || EmployeeNumber?.Length == 0 && Username?.Length == 0)
         {
             throw new InvalidOperationException("Either --employee-number or --username must be specified.");
         }
@@ -26,21 +26,21 @@ public sealed class ResetUserCommandOptions
     /// <summary>
     /// The employee number of the user.
     /// </summary>
-    public string? EmployeeNumber { get; set; }
+    public string[]? EmployeeNumber { get; set; }
 
     /// <summary>
     /// The username of the user.
     /// </summary>
-    public string? Username { get; set; }
+    public string[]? Username { get; set; }
 
     /// <summary>
     /// Parses the '--employee-number' option.
     /// </summary>
     /// <param name="parseResult">The parse result.</param>
     /// <returns>The value of the '--employee-number' option.</returns>
-    private static string? ParseEmployeeNumberOption(ParseResult parseResult)
+    private static string[]? ParseEmployeeNumberOption(ParseResult parseResult)
     {
-        return parseResult.GetValue<string>("--employee-number");
+        return parseResult.GetValue<string[]>("--employee-number");
     }
 
     /// <summary>
@@ -48,8 +48,8 @@ public sealed class ResetUserCommandOptions
     /// </summary>
     /// <param name="parseResult">The parse result.</param>
     /// <returns>The value of the '--username' option.</returns>
-    private static string? ParseUsernameOption(ParseResult parseResult)
+    private static string[]? ParseUsernameOption(ParseResult parseResult)
     {
-        return parseResult.GetValue<string>("--username");
+        return parseResult.GetValue<string[]>("--username");
     }
 }


### PR DESCRIPTION
## Description

* Adds the ability to reset multiple users when running the `reset-user` command with the CSVImporter config tool.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None