### PR TITLE
Add extra checks for home phone numbers

### DIFF
--- a/src/Lib/Models/UserDetails.cs
+++ b/src/Lib/Models/UserDetails.cs
@@ -184,9 +184,19 @@ public sealed class UserDetails
             return null;
         }
 
+        if (CsvDataRegexTools.PhoneNumberHasAreaCodeParentheses(homePhoneNumber))
+        {
+            homePhoneNumber = CsvDataRegexTools.NormalizePhoneNumberAreaCodeParentheses(homePhoneNumber);
+        }
+
         if (!CsvDataRegexTools.PhoneNumberHasCountryCode(homePhoneNumber))
         {
             homePhoneNumber = $"+1 {homePhoneNumber}";
+        }
+
+        if (!CsvDataRegexTools.IsValidPhoneNumberFormat(homePhoneNumber))
+        {
+            return null;
         }
 
         return homePhoneNumber;


### PR DESCRIPTION
## Description

- Applies the same checks, in the referenced PR, to home phone numbers, as this was overlooked in that one.

See #140.

### Type of change

- [ ] 🌟 New feature
- [x] 💪 Enhancement
- [ ] 🪳 Bug fix
- [ ] 🧹 Maintenance

### Related issues

- None